### PR TITLE
Set environment in Raven client

### DIFF
--- a/src/services/SentryService.php
+++ b/src/services/SentryService.php
@@ -96,6 +96,10 @@ class SentryService extends Component
         $user = Craft::$app->getUser()->getIdentity();
 
         $sentryClient = new Raven_Client($settings->clientDsn);
+        
+        if (CRAFT_ENVIRONMENT) {
+            $sentryClient->setEnvironment(CRAFT_ENVIRONMENT);
+        }
 
         $error_handler = new Raven_ErrorHandler($sentryClient);
         $error_handler->registerExceptionHandler();


### PR DESCRIPTION
Needed for the environment toggle to work in the Sentry dashboard.

![Sentry env toggle](https://i.imgur.com/Vw6u0Ey.png)