### PR TITLE
Add ability to save an environment as a config param and send it with the captured exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.DS_Store
+/vendor

--- a/src/controllers/SentryController.php
+++ b/src/controllers/SentryController.php
@@ -10,11 +10,8 @@
 
 namespace lukeyouell\sentry\controllers;
 
-use lukeyouell\sentry\Sentry;
-
 use Craft;
 use craft\web\Controller;
-use craft\elements\Entry;
 use lukeyouell\sentry\services\SentryService;
 
 /**

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -15,9 +15,6 @@ use lukeyouell\sentry\Sentry;
 use Craft;
 use craft\web\Controller;
 
-use yii\base\InvalidConfigException;
-use yii\web\NotFoundHttpException;
-
 class SettingsController extends Controller
 {
     // Public Properties

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -10,9 +10,6 @@
 
 namespace lukeyouell\sentry\models;
 
-use lukeyouell\sentry\Sentry;
-
-use Craft;
 use craft\base\Model;
 
 /**
@@ -26,7 +23,7 @@ class Settings extends Model
     // =========================================================================
 
     /**
-     * @var string
+     * @var boolean
      */
     public $enabled = true;
 
@@ -50,6 +47,11 @@ class Settings extends Model
      */
     public $excludedCodes = null;
 
+    /**
+     * @var string
+     */
+    public $environment = null;
+
     // Public Methods
     // =========================================================================
 
@@ -60,7 +62,7 @@ class Settings extends Model
     {
         return [
             [['enabled'], 'boolean'],
-            [['authToken', 'project', 'clientDsn', 'excludedCodes'], 'string'],
+            [['authToken', 'project', 'clientDsn', 'excludedCodes', 'environment'], 'string'],
             [['authToken'], 'required']
         ];
     }

--- a/src/services/SentryService.php
+++ b/src/services/SentryService.php
@@ -101,6 +101,12 @@ class SentryService extends Component
 
         $sentryClient = new Raven_Client($settings->clientDsn);
 
+        $environment = $settings->environment ?: CRAFT_ENVIRONMENT ?: null;
+
+        if ($environment) {
+            $sentryClient->setEnvironment($environment);
+        }
+
         $error_handler = new Raven_ErrorHandler($sentryClient);
         $error_handler->registerExceptionHandler();
         $error_handler->registerErrorHandler();
@@ -119,7 +125,7 @@ class SentryService extends Component
             'extra' => [
                 'App Type'    => 'Craft CMS',
                 'App Version' => Craft::$app->getVersion(),
-                'Environment' => CRAFT_ENVIRONMENT ?: 'undefined',
+                'Environment' => $environment ?: 'undefined',
                 'PHP Version' => phpversion(),
                 'Status Code' => $statusCode
             ]

--- a/src/templates/_settings/project/index.twig
+++ b/src/templates/_settings/project/index.twig
@@ -82,4 +82,15 @@
       label:   'Client DSN'|t,
       warning: 'clientDsn' in overrides ? macros.configWarning('clientDsn')
   }, keyInput) }}
+
+  {{ forms.textField({
+      label:        'Sentry Environment',
+      instructions: 'Sentry environment that will be attached to the events.',
+      id:           'environment',
+      name:         'settings[environment]',
+      placeholder:  'dev',
+      value:        settings.environment,
+      disabled:     'environment' in overrides,
+      warning:      'environment' in overrides ? macros.configWarning('environment')
+  }) }}
 {% endblock %}


### PR DESCRIPTION
User will be able to define a Sentry environment in their .env file so they can filter by environment the exceptions captured by Sentry. I didn't want to use the CRAFT_ENVIRONMENT since I might want to just define dev and production in Sentry independently if Craft environment is more segmented (local, staging, preproduction...). It defaults to it if the environment config is not set.

Some imports that did not seem to be used were deleted.